### PR TITLE
Last match data used as new one default values + Redirection updated

### DIFF
--- a/apps/backend/modules/matchs/actions/actions.class.php
+++ b/apps/backend/modules/matchs/actions/actions.class.php
@@ -374,7 +374,9 @@ class matchsActions extends sfActions {
 	}
 
 	public function executeCreate(sfWebRequest $request) {
-		$this->form = new MatchsForm();
+		$lastMatch = Doctrine::getTable('Matchs')->getLastMatch();
+
+		$this->form = new MatchsForm($lastMatch->getCopiedOne());
 		$this->maps = sfConfig::get("app_maps");
 
 		if ($request->getMethod() == sfWebRequest::POST) {
@@ -406,7 +408,7 @@ class matchsActions extends sfActions {
 
 				$this->getUser()->setFlash("notification_ok", $this->__("Le match a été créé avec succès et porte l'ID ") . $match->getId());
 
-				$this->redirect("matchs_create");
+				$this->redirect("matchs_current");
 			}
 		}
 	}

--- a/lib/model/doctrine/Matchs.class.php
+++ b/lib/model/doctrine/Matchs.class.php
@@ -223,4 +223,18 @@ class Matchs extends BaseMatchs {
         return $actions;
     }
 
+    public function getCopiedOne()
+    {
+        $newMatch = $this->copy();
+
+        $newMatch
+            ->setTeamA(null)
+            ->setTeamAFlag(null)
+            ->setTeamB(null)
+            ->setTeamBFlag(null)
+        ;
+
+        return $newMatch;
+    }
+
 }

--- a/lib/model/doctrine/MatchsTable.class.php
+++ b/lib/model/doctrine/MatchsTable.class.php
@@ -38,4 +38,12 @@ class MatchsTable extends Doctrine_Table {
         return $this->createQuery()->where("status = ?", Matchs::STATUS_ARCHIVE)->orderBy("id DESC");
     }
 
+    public function getLastMatch()
+    {
+        return $this->createQuery()
+            ->orderBy('created_at DESC')
+            ->fetchOne()
+        ;
+    }
+
 }


### PR DESCRIPTION
Une PR qui propose 2 évolutions : 
- Un pré-remplissage lors de la création d'un nouveau match (basée sur le dernier créé)
- Après création : une redirection vers la liste des matchs plutôt que la création d'un nouveau (car on souhaite plus souvent lancer le match qu'en recréer de suite un nouveau !)
