### PR TITLE
Automatically detect protocol for absolute paths (e.g. websocket)

### DIFF
--- a/apps/backend/templates/layout.php
+++ b/apps/backend/templates/layout.php
@@ -26,7 +26,8 @@
             function submitForm (id) {
                 $("#"+id).submit();
             }
-            
+
+            var protocol = window.location.protocol + "//";
             var socketIoAddress = "<?php echo sfConfig::get("app_ebot_ip"); ?>:<?php echo sfConfig::get("app_ebot_port"); ?>";
             var socket = null;
             var socketIoLoaded = false;
@@ -37,18 +38,18 @@
                 if (loadingSocketIo) {
                     return;
                 }
-                
+
                 if (socketIoLoaded) {
                     if (typeof callback == "function") {
                         callback(socket);
                     }
                     return;
                 }
-                
+
                 loadingSocketIo = true;
-                $.getScript("http://"+socketIoAddress+"/socket.io/socket.io.js", function(){
-                    socket = io.connect("http://"+socketIoAddress);
-                    socket.on('connect', function(){ 
+                $.getScript(protocol+socketIoAddress+"/socket.io/socket.io.js", function(){
+                    socket = io.connect(protocol+socketIoAddress);
+                    socket.on('connect', function(){
                         socketIoLoaded = true;
                         loadingSocketIo = false;
                         if (typeof callback == "function") {

--- a/apps/backend/templates/layout_external.php
+++ b/apps/backend/templates/layout_external.php
@@ -3,6 +3,7 @@
         <?php include_stylesheets() ?>
         <?php include_javascripts() ?>
         <script>
+            var protocol = window.location.protocol + "//";
             var socketIoAddress = "<?php echo sfConfig::get("app_ebot_ip"); ?>:<?php echo sfConfig::get("app_ebot_port"); ?>";
             var socket = null;
             var socketIoLoaded = false;
@@ -13,18 +14,18 @@
                 if (loadingSocketIo) {
                     return;
                 }
-                
+
                 if (socketIoLoaded) {
                     if (typeof callback == "function") {
                         callback(socket);
                     }
                     return;
                 }
-                
+
                 loadingSocketIo = true;
-                $.getScript("http://"+socketIoAddress+"/socket.io/socket.io.js", function(){
-                    socket = io.connect("http://"+socketIoAddress);
-                    socket.on('connect', function(){ 
+                $.getScript(protocol+socketIoAddress+"/socket.io/socket.io.js", function(){
+                    socket = io.connect(protocol+socketIoAddress);
+                    socket.on('connect', function(){
                         socketIoLoaded = true;
                         loadingSocketIo = false;
                         if (typeof callback == "function") {

--- a/apps/frontend/templates/layout.php
+++ b/apps/frontend/templates/layout.php
@@ -27,6 +27,7 @@
                 $("#" + id).submit();
             }
 
+            var protocol = window.location.protocol + "//";
             var socketIoAddress = "<?php echo sfConfig::get("app_ebot_ip"); ?>:<?php echo sfConfig::get("app_ebot_port"); ?>";
             var socket = null;
             var socketIoLoaded = false;
@@ -37,18 +38,18 @@
                 if (loadingSocketIo) {
                     return;
                 }
-                
+
                 if (socketIoLoaded) {
                     if (typeof callback == "function") {
                         callback(socket);
                     }
                     return;
                 }
-                
+
                 loadingSocketIo = true;
-                $.getScript("http://"+socketIoAddress+"/socket.io/socket.io.js", function(){
-                    socket = io.connect("http://"+socketIoAddress);
-                    socket.on('connect', function(){ 
+                $.getScript(protocol+socketIoAddress+"/socket.io/socket.io.js", function(){
+                    socket = io.connect(protocol+socketIoAddress);
+                    socket.on('connect', function(){
                         socketIoLoaded = true;
                         loadingSocketIo = false;
                         if (typeof callback == "function") {


### PR DESCRIPTION
I dynamically set currently used protocol (http/https), instead of using the static declaration `"http://"`.
This comes in handy when using a reverse proxy infront of eBot, because most browsers forbid loading *Mixed Content* (page over https, resource over http).