### PR TITLE
Add API filter to retrieve only not completed matches

### DIFF
--- a/apps/backend/modules/matchs/actions/actions.class.php
+++ b/apps/backend/modules/matchs/actions/actions.class.php
@@ -1078,7 +1078,7 @@ class matchsActions extends sfActions
                     );
                 }
 
-                $games = $api->get("v1/tournaments/" . $tournamentId . "/matches?with_games=1&sort=schedule", array(), true);
+                $games = $api->get("v1/tournaments/" . $tournamentId . "/matches?with_games=1&sort=schedule&has_result=0", array(), true);
                 foreach ($games as $match) {
                     $matches['stages'][$match['stage_number']]['matches'][] = $match;
                 }


### PR DESCRIPTION
Since Toornament API retrieve only the 100 first matches if you don't add a pagination filter, it sometimes retrieve only completed matches. (e.g 120 matches on 140 are completed, retrieve only completed matches and eBot don't display any match).

To prevent that, you should had the 'has_result' filter to '0', to retrieve only pending matches.

In a perfect world you should handle a pagination (in case more than a hundred matches were not completed/pending).

have a nice day ;) 