### PR TITLE
Added config entry for toggling OT by default

### DIFF
--- a/apps/backend/modules/matchs/templates/createSuccess.php
+++ b/apps/backend/modules/matchs/templates/createSuccess.php
@@ -156,6 +156,11 @@
             }
         });
 
+        if ($('#matchs_config_ot').prop('checked')) {
+            $("#overtime_startmoney").show();
+            $("#overtime_max_round").show();
+        }
+
         $("#match_startdate").datetimepicker({format: 'dd.mm.yyyy hh:ii', autoclose: true, language: 'de'});
     });
 </script>

--- a/config/app_user.yml.default
+++ b/config/app_user.yml.default
@@ -8,6 +8,7 @@
 
   default_max_round: 12
   default_rules: rules
+  default_overtime_enable: false
   default_overtime_max_round: 3
   default_overtime_startmoney: 16000
 

--- a/lib/form/doctrine/MatchsForm.class.php
+++ b/lib/form/doctrine/MatchsForm.class.php
@@ -34,6 +34,7 @@ class MatchsForm extends BaseMatchsForm {
         $this->widgetSchema["max_round"]->setLabel("Max Rounds (MR)");
 
         $this->widgetSchema["config_ot"]->setLabel("OverTime");
+        $this->widgetSchema["config_ot"]->setDefault(true);
         $this->widgetSchema["config_streamer"]->setLabel("Streamer Ready");
         $this->widgetSchema["config_knife_round"]->setLabel("Knife Round");
         $this->widgetSchema["config_knife_round"]->setDefault(true);

--- a/lib/form/doctrine/MatchsForm.class.php
+++ b/lib/form/doctrine/MatchsForm.class.php
@@ -35,7 +35,7 @@ class MatchsForm extends BaseMatchsForm {
         $this->widgetSchema["max_round"]->setLabel("Max Rounds (MR)");
 
         $this->widgetSchema["config_ot"]->setLabel("OverTime");
-        $this->widgetSchema["config_ot"]->setDefault(true);
+        $this->widgetSchema["config_ot"]->setDefault(sfConfig::get("app_default_overtime_enable", false));
         $this->widgetSchema["config_streamer"]->setLabel("Streamer Ready");
         $this->widgetSchema["config_knife_round"]->setLabel("Knife Round");
         $this->widgetSchema["config_knife_round"]->setDefault(true);


### PR DESCRIPTION
Added config entry for toggling OT by default.
Since many tournaments use overtime by default, it will be useful to enable it by default from the config file to provide better UX and save additional effort of enabling OT every time while creating the match.
It is set to false by default.